### PR TITLE
feat: Make sidebar sections collapsible

### DIFF
--- a/sidebar.css
+++ b/sidebar.css
@@ -165,3 +165,51 @@ body {
 .main-content::-webkit-scrollbar-thumb:hover {
   background: #a1a7ad;
 }
+
+/* Styles for collapsible sections */
+.stats-section details {
+  border: none;
+}
+
+.stats-section summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+  padding: 0;
+  outline: none;
+}
+
+.stats-section summary h2 {
+  padding: 10px 12px;
+  margin: 0;
+  border-bottom: none;
+  width: 100%;
+}
+
+.stats-section details[open] > summary {
+  border-bottom: 1px solid var(--border-color);
+}
+
+.stats-section summary::-webkit-details-marker {
+  display: none;
+}
+
+.stats-section summary::before {
+  content: '▶';
+  font-size: 10px;
+  color: var(--text-secondary-color);
+  position: absolute;
+  right: 25px;
+  transform: rotate(0deg);
+  transition: transform 0.2s;
+}
+
+.stats-section details[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.stats-section details .content {
+  border-top: none;
+  padding-top: 0;
+}

--- a/sidebar.js
+++ b/sidebar.js
@@ -3,11 +3,21 @@ function renderStats(stats) {
   statsContainer.innerHTML = ''; // Clear previous stats
 
   // Helper to create a section
-  function createSection(title, content) {
+  function createSection(title, content, collapsible = false) {
     if (!content) return;
     const section = document.createElement('div');
     section.className = 'stats-section';
-    section.innerHTML = `<h2>${title}</h2><div class="content">${content}</div>`;
+
+    if (collapsible) {
+      section.innerHTML = `
+        <details>
+          <summary><h2>${title}</h2></summary>
+          <div class="content">${content}</div>
+        </details>
+      `;
+    } else {
+      section.innerHTML = `<h2>${title}</h2><div class="content">${content}</div>`;
+    }
     statsContainer.appendChild(section);
   }
 
@@ -30,7 +40,7 @@ function renderStats(stats) {
       colorsContent += `<li><span class="color-swatch" style="background-color:${color};"></span> ${color}</li>`;
     });
     colorsContent += '</ul>';
-    createSection('Theme Colors', colorsContent);
+    createSection('Theme Colors', colorsContent, true);
   }
   
   // Edit Links
@@ -62,7 +72,7 @@ function renderStats(stats) {
       loadTimesContent += `<li><strong>${speedName}:</strong> ${stats.estimatedTimes[speedName]} s</li>`;
     }
     loadTimesContent += '</ul>';
-    createSection('Est. Load Times', loadTimesContent);
+    createSection('Est. Load Times', loadTimesContent, true);
   }
 
   // Detected Services
@@ -82,7 +92,7 @@ function renderStats(stats) {
       servicesContent += '</li>';
     });
     servicesContent += '</ul>';
-    createSection('Detected Services', servicesContent);
+    createSection('Detected Services', servicesContent, true);
   }
 }
 


### PR DESCRIPTION
This commit introduces collapsible sections for "Theme Colors," "Est. Load Times," and "Detected Services" in the sidebar UI.

- Updated `sidebar.js` to dynamically create `<details>` and `<summary>` elements for the specified sections.
- Added styles to `sidebar.css` to ensure the new dropdowns match the existing UI design and are user-friendly.