### PR TITLE
feat: Add body attributes and make images collapsible

### DIFF
--- a/content.js
+++ b/content.js
@@ -7,8 +7,11 @@ style.innerHTML = `
 `;
 document.head.appendChild(style);
 
-const bodyText = document.body.innerText;
+const bodyElement = document.body;
+const bodyText = bodyElement.innerText;
 const wordCount = bodyText.split(/\s+/).length;
+const bodyClasses = Array.from(bodyElement.classList);
+const bodyId = bodyElement.id;
 
 // --- Link Analysis ---
 const allLinks = document.getElementsByTagName('a');
@@ -252,7 +255,9 @@ setTimeout(() => {
     fcp: fcp,
     lcp: lcp,
     cls: cls,
-    detectedServices: finalServices
+    detectedServices: finalServices,
+    bodyClasses: bodyClasses,
+    bodyId: bodyId
   }});
 
 }, 1000); // 1-second delay

--- a/sidebar.js
+++ b/sidebar.js
@@ -31,7 +31,21 @@ function renderStats(stats) {
   `;
   createSection('General', generalContent);
 
-  
+  // Body Classes and ID
+  if (stats.bodyId || (stats.bodyClasses && stats.bodyClasses.length > 0)) {
+    let bodyContent = '';
+    if (stats.bodyId) {
+      bodyContent += `<p><strong>ID:</strong> ${stats.bodyId}</p>`;
+    }
+    if (stats.bodyClasses && stats.bodyClasses.length > 0) {
+      bodyContent += `<strong>Classes:</strong><ul>`;
+      stats.bodyClasses.forEach(cls => {
+        bodyContent += `<li>${cls}</li>`;
+      });
+      bodyContent += '</ul>';
+    }
+    createSection('Body Tag', bodyContent, true);
+  }
 
   // Theme Colors
   if (stats.themeColors && stats.themeColors.length > 0) {
@@ -62,7 +76,7 @@ function renderStats(stats) {
       }
     });
     imagesContent += '</ul>';
-    createSection('Largest Images', imagesContent);
+    createSection('Largest Images', imagesContent, true);
   }
 
   // Estimated Load Times


### PR DESCRIPTION
This commit introduces two main enhancements to the Page Stats sidebar:

1.  A new collapsible section has been added to display the ID and a list of classes from the `<body>` tag of the analyzed page. This information is now extracted in `content.js` and rendered in `sidebar.js`.
2.  The "Largest Images" section is now collapsible, consistent with the behavior of other list-based sections in the sidebar.